### PR TITLE
fix(#3): error when bookmark alias does not exist

### DIFF
--- a/lynx.c
+++ b/lynx.c
@@ -140,6 +140,9 @@ void remove_bookmark(sqlite3 *db, char *alias) {
   if (sqlite3_step(stmt) != SQLITE_DONE) {
     nob_log(ERROR, "%s", sqlite3_errmsg(db));
   }
+  if (sqlite3_changes(db) == 0) {
+    nob_log(ERROR, "no bookmark found with alias %s", alias);
+  }
 }
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
# Fix delete command when bookmark alias does not exist (#3)
Prevent silent success when deleting a non-existent bookmark. Closes #3.

